### PR TITLE
feat: 优化 RustFS Helm Chart 配置

### DIFF
--- a/rustfs/templates/service.yaml
+++ b/rustfs/templates/service.yaml
@@ -31,7 +31,7 @@ spec:
   #  type: LoadBalancer
   publishNotReadyAddresses: true
   ports:
-    - port: 80
+    - port: {{ .Values.service.ep_port }}
       targetPort: {{ .Values.service.ep_port }}
       protocol: TCP
       name: endpoint

--- a/rustfs/templates/statefulset.yaml
+++ b/rustfs/templates/statefulset.yaml
@@ -25,6 +25,17 @@ spec:
             - sh
             - -c
             - |
+              # 等待所有 Pod 都启动完成
+              echo "Waiting for all pods to be ready..."
+              for i in $(seq 0 $(($REPLICA_COUNT - 1))); do
+                while ! nslookup rustfs-$i.rustfs-headless.rustfs.svc.cluster.local >/dev/null 2>&1; do
+                  echo "Waiting for rustfs-$i to be ready..."
+                  sleep 2
+                done
+                echo "rustfs-$i is ready"
+              done
+              echo "All pods are ready, proceeding with initialization..."
+
               if [ "$REPLICA_COUNT" -eq 4 ]; then
                 for i in $(seq 0 $(($REPLICA_COUNT - 1))); do
                   mkdir -p /data/rustfs$i
@@ -39,7 +50,7 @@ spec:
             {{- if eq (int .Values.replicaCount) 4 }}
             {{- range $i := until (int .Values.replicaCount) }}
             - name: data-rustfs-{{ $i }}
-              mountPath: /data/rustfs-{{ $i }}
+              mountPath: /data/rustfs{{ $i }}
             {{- end }}
             {{- else if eq (int .Values.replicaCount) 16 }}
             - name: data
@@ -50,8 +61,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          command: [ "/bin/sh", "-c" ]
-          args: [ "/usr/bin/rustfs $RUSTFS_VOLUMES" ]
+          command: ["/usr/bin/rustfs"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             runAsUser: 1000
@@ -60,6 +70,9 @@ spec:
               name: endpoint
             - containerPort: {{ .Values.service.console_port }}
               name: console
+          env:
+            - name: REPLICA_COUNT
+              value: "{{ .Values.replicaCount }}"
           envFrom:
             - configMapRef:
                 name: {{ include "rustfs.fullname" . }}-config
@@ -75,8 +88,11 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 9000
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 5
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
           volumeMounts:
             - name: logs
               mountPath: /logs

--- a/rustfs/values.yaml
+++ b/rustfs/values.yaml
@@ -11,7 +11,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.0.0-alpha.56"
+  tag: "1.0.0-alpha.57"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -35,7 +35,6 @@ config:
     sinks_file_path: "/logs"
     obs_log_directory: "/logs"
 
-
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
   # Specifies whether a service account should be created
@@ -55,10 +54,12 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -67,15 +68,16 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
-  type: ClusterIP
-  ep_port: 80
+  type: NodePort
+  ep_port: 9000
   console_port: 9001
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -83,7 +85,7 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls: 
+  tls:
     - secretName: rustfs-tls
       hosts:
         - your.rustfs.com
@@ -95,7 +97,7 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 200m
-    memory: 512Mi 
+    memory: 512Mi
   requests:
     cpu: 100m
     memory: 256Mi


### PR DESCRIPTION
- 更新镜像版本到 1.0.0-alpha.57
- 修改服务类型为 NodePort，端口改为 9000
- 优化 StatefulSet 初始化逻辑，添加 Pod 就绪等待机制
- 修复数据卷挂载路径问题
- 改进健康检查配置，增加超时和重试机制
- 优化容器启动命令和环境变量配置